### PR TITLE
feat: Add option to include page numbers in PDF

### DIFF
--- a/diagram/pdf_service.py
+++ b/diagram/pdf_service.py
@@ -18,7 +18,8 @@ def create_pdf_from_fens(
     board_colors=None,
     columns_for_diagrams_per_page=None,
     title=None,
-    show_turn_indicator=False
+    show_turn_indicator=False,
+    show_page_numbers=False
 ):
     """
     Creates a PDF document with a grid layout of chess diagrams from a list of FEN objects.
@@ -144,7 +145,21 @@ def create_pdf_from_fens(
         # Remove the last PageBreak
         story.pop()
 
-    doc.build(story)
+    def draw_page_number(canvas, doc):
+        canvas.saveState()
+        canvas.setFont('Times-Roman', 10)
+        page_number_text = f"Page {doc.page}"
+        canvas.drawCentredString(
+            A4[0] / 2,
+            20,
+            page_number_text
+        )
+        canvas.restoreState()
+
+    if show_page_numbers:
+        doc.build(story, onFirstPage=draw_page_number, onLaterPages=draw_page_number)
+    else:
+        doc.build(story)
 
     pdf_data = buffer.getvalue()
     buffer.close()

--- a/diagram/views.py
+++ b/diagram/views.py
@@ -22,6 +22,7 @@ class GeneratePdfApiView(APIView):
         columns_for_diagrams_per_page = request.data.get('columns_for_diagrams_per_page')
         title = request.data.get('title')
         show_turn_indicator = request.data.get('show_turn_indicator', False)
+        show_page_numbers = request.data.get('show_page_numbers', False)
 
 
         if not fens or not isinstance(fens, list):
@@ -47,7 +48,8 @@ class GeneratePdfApiView(APIView):
                 board_colors,
                 columns_for_diagrams_per_page,
                 title if title != '' else None,
-                show_turn_indicator
+                show_turn_indicator,
+                show_page_numbers
             )
 
             response = HttpResponse(pdf_data, content_type='application/pdf')

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -71,6 +71,7 @@ function App() {
       },
       title: values.title,
       show_turn_indicator: values.showTurnIndicator,
+      show_page_numbers: values.showPageNumbers,
     };
 
     try {
@@ -141,6 +142,7 @@ function App() {
                     singleColumn: 1,
                     twoColumnMax: 8,
                     showTurnIndicator: true,
+                    showPageNumbers: false,
                   }}
                 >
                   <Form.Item
@@ -214,6 +216,10 @@ function App() {
 
                   <Form.Item name="showTurnIndicator" valuePropName="checked" style={{ marginTop: '16px' }}>
                     <Checkbox>Show turn indicator for Black</Checkbox>
+                  </Form.Item>
+
+                  <Form.Item name="showPageNumbers" valuePropName="checked" style={{ marginTop: '16px' }}>
+                    <Checkbox>Show page numbers</Checkbox>
                   </Form.Item>
 
                   <Form.Item style={{ marginTop: '24px' }}>


### PR DESCRIPTION
This commit introduces a new feature that allows users to add page numbers to the generated PDF document.

- A "Show page numbers" checkbox has been added to the frontend application.
- The backend API has been updated to accept a `show_page_numbers` parameter.
- The PDF generation service now conditionally adds centered page numbers at the bottom of each page if the option is enabled.