### PR TITLE
fix setup instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Follow these instructions to set up the project for development.
 
 1.  **In a new terminal**, navigate to the frontend project directory:
     ```bash
-    cd chess_pdf_generator/frontend
+    cd frontend
     ```
 
 2.  **Install Node.js dependencies:**


### PR DESCRIPTION
The setup instruction for the fronted server specified a path that was incorrect:
chess_pdf_generator/frontend
instead of frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated path references in documentation to reflect current project structure and improve clarity for setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->