### PR TITLE
Make backend port configurable via BACKEND_PORT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Follow these instructions to set up the project for development.
 
 1.  **In a new terminal**, navigate to the frontend project directory:
     ```bash
-    cd chess_pdf_generator/frontend
+    cd frontend
     ```
 
 2.  **Install Node.js dependencies:**

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ To quickly start the application for development, you can use the provided scrip
 
 The servers will run in the background. To view logs, you can check `/tmp/backend.log` and `/tmp/frontend.log`.
 
+> **Using a different backend port:** If port `8000` is already taken, set the `BACKEND_PORT` environment variable before running the script. Both the Django server and the frontend's Vite proxy read it, so they stay in sync:
+> ```bash
+> BACKEND_PORT=8001 ./start_servers.sh
+> ```
+
 ## Setup and Installation
 
 Follow these instructions to set up the project for development.
@@ -92,6 +97,15 @@ Follow these instructions to set up the project for development.
     python manage.py runserver
     ```
     The backend API will be running at `http://localhost:8000`.
+
+    To use a different port (e.g. if `8000` is busy), pass it as an argument:
+    ```bash
+    python manage.py runserver 8001
+    ```
+    When running the frontend separately, set the matching `BACKEND_PORT` so its proxy points to the right place:
+    ```bash
+    BACKEND_PORT=8001 npm run dev
+    ```
 
 ### Frontend Setup
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,13 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Backend port can be overridden via the BACKEND_PORT env var (defaults to 8000).
+// Keep this in sync with the port passed to `manage.py runserver`.
+const backendPort = process.env.BACKEND_PORT || '8000';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: `http://localhost:${backendPort}`,
         changeOrigin: true,
         secure: false,
       },

--- a/start_servers.sh
+++ b/start_servers.sh
@@ -3,6 +3,11 @@
 # Exit on any error
 set -e
 
+# Port the backend (Django) listens on. Override with: BACKEND_PORT=8001 ./start_servers.sh
+# The frontend's Vite proxy reads the same variable, so both stay in sync automatically.
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+export BACKEND_PORT
+
 # --- Backend Setup ---
 echo "--- Setting up backend ---"
 python3 -m venv venv
@@ -10,7 +15,8 @@ source venv/bin/activate
 pip install -r requirements.txt
 echo "--- Starting backend server ---"
 
-python manage.py runserver > /tmp/backend.log 2>&1 &
+echo "--- Backend will listen on port ${BACKEND_PORT} ---"
+python manage.py runserver "${BACKEND_PORT}" > /tmp/backend.log 2>&1 &
 
 # --- Frontend Setup ---
 echo "--- Setting up frontend ---"


### PR DESCRIPTION
## Summary

The Django dev server and the frontend's Vite proxy were both hardcoded to port `8000`, so there was no easy way to run the backend elsewhere if `8000` was already taken.

This change reads an optional `BACKEND_PORT` environment variable (defaulting to `8000`) in both places so they stay in sync:

- **`start_servers.sh`** — reads and exports `BACKEND_PORT`, passes it to `python manage.py runserver`, and echoes the chosen port.
- **`frontend/vite.config.js`** — the proxy `target` now uses `process.env.BACKEND_PORT` (falling back to `8000`).
- **`README.md`** — documents `BACKEND_PORT=8001 ./start_servers.sh` and the manual equivalents.

Behavior is unchanged when the variable is unset: everything still defaults to `8000`.

## Usage

```bash
BACKEND_PORT=8001 ./start_servers.sh
```

## Test plan

- [x] `bash -n start_servers.sh` passes.
- [x] With `BACKEND_PORT=8001`, the Vite proxy resolves to `http://localhost:8001`; unset, it stays at `http://localhost:8000`.
- [x] Confirmed the frontend reaches the backend via the relative `/api` path (`src/App.jsx`) through the proxy — no other hardcoded port references exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable backend port support via the `BACKEND_PORT` environment variable, allowing the app to run when the default port 8000 is unavailable while keeping frontend and backend synchronized.

* **Documentation**
  * Enhanced setup instructions with guidance on setting custom backend ports for both combined and individual server runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->